### PR TITLE
add option to `prefer-constant` to handle function declarations (fixes #70)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ## [Unreleased][unreleased]
 ### Added
-- (none)
+- Added option for `prefer-constant` to handle function declarations.
 
 [unreleased]: https://github.com/wix/eslint-plugin-lodash/compare/v1.7.0...HEAD
 

--- a/docs/rules/prefer-constant.md
+++ b/docs/rules/prefer-constant.md
@@ -4,7 +4,9 @@ When you want a function that always returns the same value, it can be more conc
 
 ## Rule Details
 
-This rule takes one argument: whether or not to check arrow functions.
+This rule takes two arguments:
+- whether or not to check arrow functions
+- whether or not to check function declarations
 
 The following patterns are considered warnings:
 
@@ -14,6 +16,9 @@ var three = function() { return 3;}
 
 //When including arrow functions:
 var pi = () => 3.1415;
+
+//When including function declarations:
+function one() { return 1; }
 
 ```
 

--- a/src/rules/prefer-constant.js
+++ b/src/rules/prefer-constant.js
@@ -10,6 +10,7 @@
 module.exports = function (context) {
     const astUtil = require('../util/astUtil')
     const shouldCheckArrowFunctions = context.options[0] !== undefined ? context.options[0] : true
+    const shouldCheckFunctionDeclarations = context.options[1] !== undefined ? context.options[1] : false
 
     function isCompletelyLiteral(node) {
         switch (node.type) {
@@ -26,15 +27,28 @@ module.exports = function (context) {
         }
     }
 
-    function handleFunctionExpression(node) {
-        const valueReturnedInFirstLine = astUtil.getValueReturnedInFirstLine(node)
+    function reportIfLikeConstant(func, node) {
+        const valueReturnedInFirstLine = func(node)
         if (valueReturnedInFirstLine && isCompletelyLiteral(valueReturnedInFirstLine)) {
             context.report(node, 'Prefer _.constant over a function returning a literal')
         }
     }
 
+    function handleFunctionExpression(node) {
+        reportIfLikeConstant(astUtil.getValueReturnedInFirstLine, node)
+    }
+
+    function handleFunctionDeclaration(node) {
+        reportIfLikeConstant(astUtil.getValueReturnedInFirstLineInFuncDecl, node)
+    }
+
     return {
         FunctionExpression: handleFunctionExpression,
+        FunctionDeclaration(node) {
+            if (shouldCheckFunctionDeclarations) {
+                handleFunctionDeclaration(node)
+            }
+        },
         ArrowFunctionExpression(node) {
             if (shouldCheckArrowFunctions) {
                 handleFunctionExpression(node)
@@ -44,6 +58,9 @@ module.exports = function (context) {
 }
 
 module.exports.schema = [
+    {
+        type: 'boolean'
+    },
     {
         type: 'boolean'
     }

--- a/src/util/astUtil.js
+++ b/src/util/astUtil.js
@@ -32,13 +32,15 @@ const isFunctionDefinitionWithBlock = _.overSome(
     _.matches({type: 'ArrowFunctionExpression', body: {type: 'BlockStatement'}})
 )
 
+const getFirstBlockLine = _.property(['body', 'body', 0])
+
 /**
  * If the node specified is a function, returns the node corresponding with the first statement/expression in that function
  * @param {Object} node
  * @returns {node|undefined}
  */
 const getFirstFunctionLine = _.cond([
-    [isFunctionDefinitionWithBlock, _.property(['body', 'body', 0])],
+    [isFunctionDefinitionWithBlock, getFirstBlockLine],
     [_.matches({type: 'ArrowFunctionExpression'}), _.property('body')]
 ])
 
@@ -177,6 +179,19 @@ function getValueReturnedInFirstLine(func) {
 }
 
 /**
+ * Returns the node of the value returned in the first line, if any
+ * @param {Object} func
+ * @returns {Object|null}
+ */
+function getValueReturnedInFirstLineInFuncDecl(func) {
+    if (func && _.matchesProperty('type', 'FunctionDeclaration')(func)) {
+        const firstLine = getFirstBlockLine(func)
+        return isReturnStatement(firstLine) ? firstLine.argument : null
+    }
+    return null
+}
+
+/**
  * Returns whether the node is a call from the specified object name
  * @param {Object} node
  * @param {string} objName
@@ -301,6 +316,7 @@ module.exports = {
     isIdentifierOfParam,
     isNegationExpression,
     getValueReturnedInFirstLine,
+    getValueReturnedInFirstLineInFuncDecl,
     isCallFromObject,
     isComputed,
     isEquivalentExp,

--- a/tests/lib/rules/prefer-constant.js
+++ b/tests/lib/rules/prefer-constant.js
@@ -21,7 +21,8 @@ ruleTester.run('prefer-constant', rule, {
         'var x = function() {return y ? 1 : 2}',
         'var x = function() {return true ? 1 : x}',
         {code: 'var x = function() { return {[y]: 1}}', parserOptions: {ecmaVersion: 6}},
-        {code: 'var x = () => 1', parserOptions: {ecmaVersion: 6}, options: [false]}
+        {code: 'var x = () => 1', parserOptions: {ecmaVersion: 6}, options: [false]},
+        'function one() { return 1; }'
     ],
     invalid: [{
         code: 'var x = function() { return 1; }',
@@ -36,6 +37,10 @@ ruleTester.run('prefer-constant', rule, {
         code: 'var x = () => 1',
         parserOptions: {ecmaVersion: 6},
         options: [true],
+        errors
+    }, {
+        code: 'function one() { return 1; }',
+        options: [true, true],
         errors
     }]
 })


### PR DESCRIPTION
add option to `prefer-constant` to handle function declarations (fixes #70)

I could have simply changed `astUtils.getFirstFunctionLine()` to handle `FunctionDeclaration` and that would have simplified a lot of stuff, but I was concerned that it might have unwanted side-effects. let me know if you think that is actually safe.

I didn't name the argument, as the existing one wasn't an object either.

Let me know if you want me to change anything :)