### PR TITLE
add eslint peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
   },
   "homepage": "https://github.com/wix/eslint-plugin-lodash",
   "bugs": "https://github.com/wix/eslint-plugin-lodash/issues",
+  "peerDependencies": {
+    "eslint": ">=1.3.0"
+  },
   "dependencies": {
     "lodash": "^4.9.0"
   },


### PR DESCRIPTION
At least one rule (prefer-lodash-method) requires eslint >=1.3.0, which is when getSourceCode was added.  
(See https://github.com/eslint/eslint/commit/fc3bc8adde6cd428f7cbbce6505bd28df287d5e5#diff-b6559e6b095a292d244b6b7bae986291R939)