### PR TITLE
Fixed crash in `chaining` rule

### DIFF
--- a/src/rules/chaining.js
+++ b/src/rules/chaining.js
@@ -48,7 +48,10 @@ module.exports = {
         const callExpressionVisitors = {
             always: node => {
                 if (isNestedNLevels(node, ruleDepth)) {
-                    context.report(getCaller(node.arguments[0]), 'Prefer chaining to composition')
+                    const args = node.arguments[0]
+                    const culprit = args.callee.type === "Identifier" ? args.callee : getCaller(args)
+
+                    context.report(culprit, 'Prefer chaining to composition')
                 } else if (lodashContext.isLodashChainStart(node)) {
                     const firstCall = node.parent.parent
                     if (isMethodCall(firstCall) && (isEndOfChain(firstCall) || isBeforeChainBreaker(firstCall))) {

--- a/tests/lib/rules/chaining.js
+++ b/tests/lib/rules/chaining.js
@@ -37,8 +37,9 @@ const testCases = {
     },
     invalid: {
         always: [
-            'var x = _.map(_.filter(_.uniq(a), g), f)'
-        ].map(code => ({code, options: ['always']})).map(fromMessage(messages.always)),
+            'var x = _.map(_.filter(_.uniq(a), g), f)',
+            'import _map from "lodash/map"; import _filter from "lodash/filter"; var x = _map(_filter(_.uniq(a), g), f)'
+        ].map(code => ({code, options: ['always'], parserOptions: {sourceType: 'module'}})).map(fromMessage(messages.always)),
         single: [
             'var x = _(a).map(f).value()',
             'var x = _(a).reduce(g, {})'


### PR DESCRIPTION
I'm pretty sure this isn't the best fix for the real problem, perhaps you can be of help here. Thus, I've split the failing test and my "fix" so you can cherry-pick if you want. 

At first, I wanted to put the fix in `getCaller`, but it would break that contract: https://github.com/wix/eslint-plugin-lodash/blob/7987717b3795e43e99b4e72c94fd0651652e85b2/tests/lib/util/astUtil.js#L16-L23