### PR TITLE
adding more string methods to `prefer-lodash-method` rule. fixes #136.

### DIFF
--- a/docs/rules/prefer-lodash-method.md
+++ b/docs/rules/prefer-lodash-method.md
@@ -11,7 +11,7 @@ This rule takes one argument - an optional options object. This object can have 
 - `ignoreObjects`: contains an array of regular expressions for objects that should not be reported on
 
 
-Examples: 
+Examples:
 
 If you do not wish to use `_.keys` but prefer `Object.keys`, the config would be:
 ```json
@@ -58,6 +58,8 @@ The following patterns are considered warnings:
 ```js
 
 var b = a.map(f);
+var c = arr.map(f).reduce(g);
+var d = 'hello'.toUpperCase();
 
 if (arr.some(f)) {
   // ...
@@ -69,9 +71,13 @@ The following patterns are not considered warnings:
 
 ```js
 
-_.map(a, f);
+var b = _.map(a, f);
+var c = _(arr).map(f).reduce(g);
+var d = _.toUpper('hello');
 
- _(arr).map(f).reduce(g);
+if (_.some(arr, f)) {
+  // ...
+}
 
 ```
 

--- a/tests/lib/rules/prefer-lodash-method.js
+++ b/tests/lib/rules/prefer-lodash-method.js
@@ -53,8 +53,40 @@ ruleTester.run('prefer-lodash-method', rule, {
         code: 'var x = Object.create(foo)',
         errors: [{message: "Prefer '_.create' over the native function."}]
     }, {
+        code: 'var x = fn().endsWith("something")',
+        errors: [{message: "Prefer '_.endsWith' over the native function."}]
+    }, {
+        code: 'var x = str.endsWith("something")',
+        errors: [{message: "Prefer '_.endsWith' over the native function."}]
+    }, {
+        code: 'var x = str.includes("something")',
+        errors: [{message: "Prefer '_.includes' over the native function."}]
+    }, {
+        code: 'var x = str.padEnd(42)',
+        errors: [{message: "Prefer '_.padEnd' over the native function."}]
+    }, {
+        code: 'var x = str.padStart(42, "foo")',
+        errors: [{message: "Prefer '_.padStart' over the native function."}]
+    }, {
+        code: 'var x = str.repeat(42)',
+        errors: [{message: "Prefer '_.repeat' over the native function."}]
+    }, {
+        code: 'var x = str.replace("foo", "bar")',
+        errors: [{message: "Prefer '_.replace' over the native function."}]
+    }, {
+        code: 'var x = str.split("-")',
+        errors: [{message: "Prefer '_.split' over the native function."}]
+    }, {
         code: 'var x = str.startsWith("something")',
         errors: [{message: "Prefer '_.startsWith' over the native function."}]
-
+    }, {
+        code: 'var x = str.toUpperCase()',
+        errors: [{message: "Prefer '_.toUpper' over the native function."}]
+    }, {
+        code: 'var x = str.toLowerCase()',
+        errors: [{message: "Prefer '_.toLower' over the native function."}]
+    }, {
+        code: 'var x = str.trim()',
+        errors: [{message: "Prefer '_.trim' over the native function."}]
     }].map(withDefaultPragma)
 })


### PR DESCRIPTION
The following string methods are now reported on:
- repeat
- replace
- split
- toLowerCase (toLower)
- toUpperCase (toUpper)
- trim