### PR TITLE
make sure v4 string methods don't break for v3 users

### DIFF
--- a/src/rules/prefer-lodash-method.js
+++ b/src/rules/prefer-lodash-method.js
@@ -32,7 +32,7 @@ module.exports = {
 
         const {getLodashContext, isNativeCollectionMethodCall, getLodashMethodCallExpVisitor} = require('../util/lodashUtil')
         const {getMethodName, getCaller} = require('../util/astUtil')
-        const keys = require('lodash/keys')
+        const {isMethodSupported} = require('../util/methodDataUtil')
         const get = require('lodash/get')
         const includes = require('lodash/includes')
         const matches = require('lodash/matches')
@@ -58,6 +58,7 @@ module.exports = {
         }
 
         const lodashContext = getLodashContext(context)
+        const {version} = lodashContext
 
         function isNonNullObjectCreate(callerName, methodName, arg) {
             return callerName === 'Object' && methodName === 'create' && get(arg, 'value') !== null
@@ -74,7 +75,8 @@ module.exports = {
         }
 
         function isNativeStringMethodCall(node) {
-            return includes(keys(nativeStringMap), getMethodName(node))
+            const methodName = getMethodName(node)
+            return nativeStringMap.hasOwnProperty(methodName) && isMethodSupported(version, nativeStringMap[methodName])
         }
 
         function canUseLodash(node) {

--- a/src/util/methodDataByVersion/4.js
+++ b/src/util/methodDataByVersion/4.js
@@ -257,6 +257,7 @@ module.exports = {
         reject: 2,
         remove: 2,
         repeat: 2,
+        replace: 3,
         rest: 2,
         result: 3,
         reverse: 1,

--- a/src/util/methodDataUtil.js
+++ b/src/util/methodDataUtil.js
@@ -132,6 +132,16 @@ function getFunctionMaxArity(version, name) {
     return getMethodData(version).args[name] || Infinity
 }
 
+/**
+ * Returns whether or not a method is supported in the given version of lodash
+ * @param {number} version
+ * @param {string} name
+ * @returns {boolean}
+ */
+function isMethodSupported(version, name) {
+    return getMethodData(version).args.hasOwnProperty(name)
+}
+
 const sideEffectIterationMethods = ['forEach', 'forEachRight', 'forIn', 'forInRight', 'forOwn', 'forOwnRight']
 
 /**
@@ -153,6 +163,7 @@ module.exports = {
     getMainAlias,
     getIterateeIndex,
     getFunctionMaxArity,
+    isMethodSupported,
     getSideEffectIterationMethods
 }
 


### PR DESCRIPTION
This is fixing a comment made here: https://github.com/wix/eslint-plugin-lodash/pull/137#issuecomment-286918728

Now, when using `plugin:lodash/v3`, the following string methods will not throw errors:
- replace
- split
- toLowerCase (toLower)
- toUpperCase (toUpper)

I still haven't addressed issue #139 (because that was an existing issue that was just exposed by adding the new string methods).  I feel like there *might* be something in astUtil.js that could help, but it might require a new function.