### PR TITLE
Failing matches-shorthand test

### DIFF
--- a/tests/lib/rules/matches-shorthand.js
+++ b/tests/lib/rules/matches-shorthand.js
@@ -26,6 +26,8 @@ ruleTester.run('matches-shorthand', rule, {
         'var isPublic = _.map([], function (i) { return i.id + "?"; });',
         'lang.fonts = _.filter(lang.fonts, function (font) { return font.permissions !== "legacy"});',
         'var isPublic = _.findLastIndex([], function (i) { return i.id == 3 && f(i); });',
+        'var result = _.filter(users, _.matches({age: 30, name: "Bob"}));',
+        'var x = _.matches({age: 30, name: "Bob"});var result = _.filter(users, x);',
         {
             code: 'var isPublic = _.find([], function(i) { return i.id === 3});',
             options: ['never']


### PR DESCRIPTION
(Intended as a demo, not to be merged)

Should this line fail the rule?
```js
var result = _.filter(users, _.matches({age: 30, name: "Bob"}));
```
If so, why?

[Failure in travis](https://travis-ci.org/wix/eslint-plugin-lodash/builds/239279413?utm_source=github_status&utm_medium=notification).

For comparison, when extracting the `_.matches` value to a variable, it doesn't fail. (the second line added).

If this is indeed an error, it might also affect the other '*-shorthand' rules.

CC @tombigel 