### PR TITLE
Update prefer-flat-map.md

### DIFF
--- a/docs/rules/prefer-flat-map.md
+++ b/docs/rules/prefer-flat-map.md
@@ -9,7 +9,7 @@ This rule takes no arguments.
 The following patterns are considered warnings:
 
 ```js
-t = _.map(a, f);
+_(a).map(f).flatten().value();
 
 t = _.flatten(_.map(a, f));
 ```
@@ -17,14 +17,15 @@ t = _.flatten(_.map(a, f));
 The following patterns are not considered warnings:
 
 ```js
-_(a).map(f).flatten().value;
+t = _.map(a, f);
 
 t = _.flatMap(a, f);
 ```
 
-
 ## When Not To Use It
-##### This rule is only relevant for Lodash 4. If you don't use Lodash 4, you should not use this rule.
+
+**This rule is only relevant for Lodash 4. If you don't use Lodash 4, you should not use this rule.**
+
 If you do not want to enforce using [`_.flatMap`], and prefer [`_.map`] and [`_.flatten`] instead, you should not use this rule.
 
 [`_.flatMap`]: https://lodash.com/docs#flatMap


### PR DESCRIPTION
`t = _.map(a, f);` should **not** warn and `_(a).map(f).flatten().value;` **should** warn.  
`.value` should be `.value()`