### PR TITLE
Docs: `preferred-alias` example is not relevant for Lodash v4

### DIFF
--- a/docs/rules/preferred-alias.md
+++ b/docs/rules/preferred-alias.md
@@ -9,13 +9,13 @@ This rule takes no arguments.
 The following patterns are considered warnings:
 
 ```js
-var ids = _.collect(users, 'id');
+_.each(users, f);
 ```
 
 The following patterns are not considered warnings:
 
 ```js
-var ids = _.map(users, 'id');
+_.forEach(users, f);
 ```
 
 


### PR DESCRIPTION
In Lodash v4, `collect` is no longer an alias of `map`