### PR TITLE
Add URL to rule documentation to the metadata

### DIFF
--- a/src/rules/callback-binding.js
+++ b/src/rules/callback-binding.js
@@ -11,6 +11,12 @@
 // ------------------------------------------------------------------------------
 
 module.exports = {
+    meta: {
+        docs: {
+            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/callback-binding.md'
+        }
+    },
+
     create(context) {
         const {getLodashMethodVisitors} = require('../util/lodashUtil')
         const {getFunctionMaxArity} = require('../util/methodDataUtil')

--- a/src/rules/chain-style.js
+++ b/src/rules/chain-style.js
@@ -11,6 +11,9 @@
 //------------------------------------------------------------------------------
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/chain-style.md'
+        },
         schema: [{
             enum: ['as-needed', 'implicit', 'explicit']
         }]

--- a/src/rules/chaining.js
+++ b/src/rules/chaining.js
@@ -12,6 +12,9 @@
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/chaining.md'
+        },
         schema: [{
             enum: ['always', 'never']
         }, {

--- a/src/rules/collection-method-value.js
+++ b/src/rules/collection-method-value.js
@@ -10,6 +10,12 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 module.exports = {
+    meta: {
+        docs: {
+            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/collection-method-value.md'
+        }
+    },
+
     create(context) {
         const {isChainBreaker, getLodashMethodVisitors, isCallToMethod} = require('../util/lodashUtil')
         const {getMethodName} = require('../util/astUtil')

--- a/src/rules/collection-return.js
+++ b/src/rules/collection-return.js
@@ -11,6 +11,12 @@
 //------------------------------------------------------------------------------
 
 module.exports = {
+    meta: {
+        docs: {
+            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/collection-return.md'
+        }
+    },
+
     create(context) {
         const {getLodashMethodCallExpVisitor, getLodashContext} = require('../util/lodashUtil')
         const {isCollectionMethod} = require('../util/methodDataUtil')

--- a/src/rules/consistent-compose.js
+++ b/src/rules/consistent-compose.js
@@ -10,6 +10,9 @@ const possibleDirections = ['pipe', 'compose', 'flow', 'flowRight']
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/consistent-compose.md'
+        },
         schema: [{
             enum: possibleDirections
         }]

--- a/src/rules/identity-shorthand.js
+++ b/src/rules/identity-shorthand.js
@@ -13,6 +13,9 @@
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/identity-shorthand.md'
+        },
         schema: [{
             enum: ['always', 'never']
         }]

--- a/src/rules/import-scope.js
+++ b/src/rules/import-scope.js
@@ -34,10 +34,14 @@ const allImportsAreOfType = (node, types) => every(node.specifiers, specifier =>
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/import-scope.md'
+        },
         schema: [{
             enum: ['method', 'member', 'full', 'method-package']
         }]
     },
+
     create(context) {
         const importType = context.options[0] || 'method'
 

--- a/src/rules/matches-prop-shorthand.js
+++ b/src/rules/matches-prop-shorthand.js
@@ -11,6 +11,9 @@
 // ------------------------------------------------------------------------------
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/matches-prop-shorthand.md'
+        },
         schema: [{
             enum: ['always', 'never']
         }, {

--- a/src/rules/matches-shorthand.js
+++ b/src/rules/matches-shorthand.js
@@ -12,6 +12,9 @@
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/matches-shorthand.md'
+        },
         schema: [{
             enum: ['always', 'never']
         }, {

--- a/src/rules/no-commit.js
+++ b/src/rules/no-commit.js
@@ -11,6 +11,12 @@
 //------------------------------------------------------------------------------
 
 module.exports = {
+    meta: {
+        docs: {
+            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/no-commit.md'
+        }
+    },
+
     create(context) {
         const {getLodashContext, isCallToMethod} = require('../util/lodashUtil')
         const {isMethodCall} = require('../util/astUtil')

--- a/src/rules/no-double-unwrap.js
+++ b/src/rules/no-double-unwrap.js
@@ -12,8 +12,12 @@
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/no-double-unwrap.md'
+        },
         fixable: "code"
     },
+
     create(context) {
         const {getLodashContext, isChainBreaker, isChainable} = require('../util/lodashUtil')
         const {isMethodCall, getCaller, getMethodName} = require('../util/astUtil')

--- a/src/rules/no-extra-args.js
+++ b/src/rules/no-extra-args.js
@@ -11,6 +11,12 @@
 //------------------------------------------------------------------------------
 
 module.exports = {
+    meta: {
+        docs: {
+            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/no-extra-args.md'
+        }
+    },
+
     create(context) {
         const {version} = require('../util/settingsUtil').getSettings(context)
         const {getLodashMethodVisitors} = require('../util/lodashUtil')

--- a/src/rules/no-unbound-this.js
+++ b/src/rules/no-unbound-this.js
@@ -7,6 +7,12 @@
 //------------------------------------------------------------------------------
 
 module.exports = {
+    meta: {
+        docs: {
+            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/no-unbound-this.md'
+        }
+    },
+
     create(context) {
         const {getLodashMethodCallExpVisitor, getLodashContext} = require('../util/lodashUtil')
         const {isCollectionMethod} = require('../util/methodDataUtil')

--- a/src/rules/path-style.js
+++ b/src/rules/path-style.js
@@ -12,6 +12,9 @@
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/path-style.md'
+        },
         schema: [{
             enum: ['as-needed', 'array', 'string']
         }]

--- a/src/rules/prefer-compact.js
+++ b/src/rules/prefer-compact.js
@@ -11,6 +11,12 @@
 //------------------------------------------------------------------------------
 
 module.exports = {
+    meta: {
+        docs: {
+            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/prefer-compact.md'
+        }
+    },
+
     create(context) {
         const {getLodashMethodVisitors} = require('../util/lodashUtil')
         const {isNegationExpression, isIdentifierWithName, getValueReturnedInFirstStatement, getFirstParamName} = require('../util/astUtil')

--- a/src/rules/prefer-constant.js
+++ b/src/rules/prefer-constant.js
@@ -12,6 +12,10 @@
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/prefer-constant.md'
+        },
+
         schema: [{
             type: 'boolean'
         }, {

--- a/src/rules/prefer-filter.js
+++ b/src/rules/prefer-filter.js
@@ -12,6 +12,9 @@
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/prefer-filter.md'
+        },
         schema: [{
             type: 'integer'
         }]

--- a/src/rules/prefer-flat-map.js
+++ b/src/rules/prefer-flat-map.js
@@ -11,6 +11,12 @@
 //------------------------------------------------------------------------------
 
 module.exports = {
+    meta: {
+        docs: {
+            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/prefer-flat-map.md'
+        }
+    },
+
     create(context) {
         const {getLodashMethodVisitors, isCallToMethod, isCallToLodashMethod} = require('../util/lodashUtil')
         const {getCaller} = require('../util/astUtil')

--- a/src/rules/prefer-get.js
+++ b/src/rules/prefer-get.js
@@ -12,6 +12,9 @@
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/prefer-get.md'
+        },
         schema: [{
             type: 'integer',
             minimum: 2

--- a/src/rules/prefer-includes.js
+++ b/src/rules/prefer-includes.js
@@ -12,6 +12,9 @@
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/prefer-includes.md'
+        },
         schema: [{
             type: 'object',
             properties: {

--- a/src/rules/prefer-invoke-map.js
+++ b/src/rules/prefer-invoke-map.js
@@ -9,7 +9,9 @@
 
 module.exports = {
     meta: {
-        docs: {}
+        docs: {
+            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/prefer-invoke-map.md'
+        }
     },
 
     create(context) {

--- a/src/rules/prefer-is-nil.js
+++ b/src/rules/prefer-is-nil.js
@@ -11,6 +11,12 @@
 //------------------------------------------------------------------------------
 
 module.exports = {
+    meta: {
+        docs: {
+            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/prefer-is-nil.md'
+        }
+    },
+
     create(context) {
         const {isNegationExpression, isEquivalentMemberExp} = require('../util/astUtil')
         const {isCallToLodashMethod, getLodashContext} = require('../util/lodashUtil')

--- a/src/rules/prefer-lodash-chain.js
+++ b/src/rules/prefer-lodash-chain.js
@@ -11,6 +11,12 @@
 //------------------------------------------------------------------------------
 
 module.exports = {
+    meta: {
+        docs: {
+            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/prefer-lodash-chain.md'
+        }
+    },
+
     create(context) {
         const {getLodashContext, isChainBreaker, isNativeCollectionMethodCall, isLodashWrapperMethod} = require('../util/lodashUtil')
         const {isMethodCall, isObjectOfMethodCall, getMethodName} = require('../util/astUtil')

--- a/src/rules/prefer-lodash-method.js
+++ b/src/rules/prefer-lodash-method.js
@@ -9,6 +9,9 @@
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/prefer-lodash-method.md'
+        },
         schema: [{
             type: 'object',
             properties: {

--- a/src/rules/prefer-lodash-typecheck.js
+++ b/src/rules/prefer-lodash-typecheck.js
@@ -11,6 +11,12 @@
 //------------------------------------------------------------------------------
 
 module.exports = {
+    meta: {
+        docs: {
+            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/prefer-lodash-typecheck.md'
+        }
+    },
+
     create(context) {
         const some = require('lodash/some')
         const {getIsTypeMethod} = require('../util/lodashUtil')

--- a/src/rules/prefer-map.js
+++ b/src/rules/prefer-map.js
@@ -11,6 +11,12 @@
 //------------------------------------------------------------------------------
 
 module.exports = {
+    meta: {
+        docs: {
+            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/prefer-map.md'
+        }
+    },
+
     create(context) {
         const {getLodashMethodVisitors} = require('../util/lodashUtil')
         const {getFirstFunctionLine, hasOnlyOneStatement, getMethodName, isFunctionDefinitionWithBlock, collectParameterValues} = require('../util/astUtil')

--- a/src/rules/prefer-matches.js
+++ b/src/rules/prefer-matches.js
@@ -12,6 +12,9 @@
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/prefer-matches.md'
+        },
         schema: [{
             type: 'integer',
             minimum: 2

--- a/src/rules/prefer-noop.js
+++ b/src/rules/prefer-noop.js
@@ -11,6 +11,12 @@
 //------------------------------------------------------------------------------
 
 module.exports = {
+    meta: {
+        docs: {
+            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/prefer-noop.md'
+        }
+    },
+
     create(context) {
         const {getFirstFunctionLine} = require('../util/astUtil')
 

--- a/src/rules/prefer-over-quantifier.js
+++ b/src/rules/prefer-over-quantifier.js
@@ -11,6 +11,12 @@
 //------------------------------------------------------------------------------
 
 module.exports = {
+    meta: {
+        docs: {
+            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/prefer-over-quantifier.md'
+        }
+    },
+
     create(context) {
         const {getLodashMethodVisitors} = require('../util/lodashUtil')
         const {getValueReturnedInFirstStatement, getFirstParamName, isObjectOfMethodCall, getMethodName} = require('../util/astUtil')

--- a/src/rules/prefer-reject.js
+++ b/src/rules/prefer-reject.js
@@ -12,6 +12,9 @@
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/prefer-reject.md'
+        },
         schema: [{
             type: 'integer'
         }]

--- a/src/rules/prefer-some.js
+++ b/src/rules/prefer-some.js
@@ -12,6 +12,9 @@
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/prefer-some.md'
+        },
         schema: [{
             type: 'object',
             properties: {
@@ -21,7 +24,6 @@ module.exports = {
             }
         }]
     },
-
 
     create(context) {
         const includeNative = context.options[0] && context.options[0].includeNative

--- a/src/rules/prefer-startswith.js
+++ b/src/rules/prefer-startswith.js
@@ -11,6 +11,12 @@
 //------------------------------------------------------------------------------
 
 module.exports = {
+    meta: {
+        docs: {
+            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/prefer-startswith.md'
+        }
+    },
+
     create(context) {
         const {isIndexOfCall, getExpressionComparedToInt} = require('../util/astUtil')
         return {

--- a/src/rules/prefer-thru.js
+++ b/src/rules/prefer-thru.js
@@ -11,6 +11,12 @@
 //------------------------------------------------------------------------------
 
 module.exports = {
+    meta: {
+        docs: {
+            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/prefer-thru.md'
+        }
+    },
+
     create(context) {
         const {getLodashContext} = require('../util/lodashUtil')
         const lodashContext = getLodashContext(context)

--- a/src/rules/prefer-times.js
+++ b/src/rules/prefer-times.js
@@ -11,6 +11,12 @@
 //------------------------------------------------------------------------------
 
 module.exports = {
+    meta: {
+        docs: {
+            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/prefer-times.md'
+        }
+    },
+
     create(context) {
         const {getLodashMethodVisitors} = require('../util/lodashUtil')
         const {isAliasOfMethod} = require('../util/methodDataUtil')

--- a/src/rules/prefer-wrapper-method.js
+++ b/src/rules/prefer-wrapper-method.js
@@ -11,6 +11,12 @@
 //------------------------------------------------------------------------------
 
 module.exports = {
+    meta: {
+        docs: {
+            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/prefer-wrapper-method.md'
+        }
+    },
+
     create(context) {
         const {isLodashWrapperMethod, getLodashContext} = require('../util/lodashUtil')
         const lodashContext = getLodashContext(context)

--- a/src/rules/preferred-alias.js
+++ b/src/rules/preferred-alias.js
@@ -11,7 +11,11 @@
 //------------------------------------------------------------------------------
 
 module.exports = {
-    meta: {},
+    meta: {
+        docs: {
+            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/preferred-alias.md'
+        }
+    },
 
     create(context) {
         const {getLodashMethodVisitors} = require('../util/lodashUtil')
@@ -31,4 +35,3 @@ module.exports = {
         })
     }
 }
-

--- a/src/rules/prop-shorthand.js
+++ b/src/rules/prop-shorthand.js
@@ -13,6 +13,9 @@
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/prop-shorthand.md'
+        },
         schema: [{
             enum: ['always', 'never']
         }]

--- a/src/rules/unwrap.js
+++ b/src/rules/unwrap.js
@@ -8,6 +8,12 @@
 // ------------------------------------------------------------------------------
 
 module.exports = {
+    meta: {
+        docs: {
+            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/unwrap.md'
+        }
+    },
+
     create(context) {
         const {getLodashContext, isChainable, isCallToMethod, isChainBreaker} = require('../util/lodashUtil')
         const {getCaller} = require('../util/astUtil')


### PR DESCRIPTION
ESLint v4.15.0 added an official location for rules to store a URL to their documentation in the rule metadata in eslint/eslint#9788. This adds the URL to all the existing rules so anything consuming them can
know where their documentation is without having to resort to external packages to guess.