### PR TITLE
Use link to tagged version for rule docs

### DIFF
--- a/src/rules/callback-binding.js
+++ b/src/rules/callback-binding.js
@@ -7,10 +7,12 @@
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+const getDocsUrl = require('../util/getDocsUrl')
+
 module.exports = {
     meta: {
         docs: {
-            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/callback-binding.md'
+            url: getDocsUrl('callback-binding.md')
         }
     },
 

--- a/src/rules/chain-style.js
+++ b/src/rules/chain-style.js
@@ -6,10 +6,13 @@
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
+
+const getDocsUrl = require('../util/getDocsUrl')
+
 module.exports = {
     meta: {
         docs: {
-            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/chain-style.md'
+            url: getDocsUrl('chain-style.md')
         },
         schema: [{
             enum: ['as-needed', 'implicit', 'explicit']

--- a/src/rules/chaining.js
+++ b/src/rules/chaining.js
@@ -7,10 +7,12 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
+const getDocsUrl = require('../util/getDocsUrl')
+
 module.exports = {
     meta: {
         docs: {
-            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/chaining.md'
+            url: getDocsUrl('chaining.md')
         },
         schema: [{
             enum: ['always', 'never']

--- a/src/rules/collection-method-value.js
+++ b/src/rules/collection-method-value.js
@@ -6,10 +6,13 @@
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
+
+const getDocsUrl = require('../util/getDocsUrl')
+
 module.exports = {
     meta: {
         docs: {
-            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/collection-method-value.md'
+            url: getDocsUrl('collection-method-value.md')
         }
     },
 

--- a/src/rules/collection-return.js
+++ b/src/rules/collection-return.js
@@ -7,10 +7,12 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
+const getDocsUrl = require('../util/getDocsUrl')
+
 module.exports = {
     meta: {
         docs: {
-            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/collection-return.md'
+            url: getDocsUrl('collection-return.md')
         }
     },
 

--- a/src/rules/consistent-compose.js
+++ b/src/rules/consistent-compose.js
@@ -6,12 +6,15 @@
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
+
+const getDocsUrl = require('../util/getDocsUrl')
+
 const possibleDirections = ['pipe', 'compose', 'flow', 'flowRight']
 
 module.exports = {
     meta: {
         docs: {
-            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/consistent-compose.md'
+            url: getDocsUrl('consistent-compose.md')
         },
         schema: [{
             enum: possibleDirections

--- a/src/rules/identity-shorthand.js
+++ b/src/rules/identity-shorthand.js
@@ -7,11 +7,12 @@
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+const getDocsUrl = require('../util/getDocsUrl')
 
 module.exports = {
     meta: {
         docs: {
-            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/identity-shorthand.md'
+            url: getDocsUrl('identity-shorthand.md')
         },
         schema: [{
             enum: ['always', 'never']

--- a/src/rules/import-scope.js
+++ b/src/rules/import-scope.js
@@ -8,6 +8,7 @@
 // ------------------------------------------------------------------------------
 
 const {isFullLodashImport, getNameFromCjsRequire, getMethodImportFromName} = require('../util/importUtil')
+const getDocsUrl = require('../util/getDocsUrl')
 const every = require('lodash/every')
 const includes = require('lodash/includes')
 
@@ -32,7 +33,7 @@ const allImportsAreOfType = (node, types) => every(node.specifiers, specifier =>
 module.exports = {
     meta: {
         docs: {
-            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/import-scope.md'
+            url: getDocsUrl('import-scope.md')
         },
         schema: [{
             enum: ['method', 'member', 'full', 'method-package']

--- a/src/rules/matches-prop-shorthand.js
+++ b/src/rules/matches-prop-shorthand.js
@@ -6,10 +6,13 @@
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+const getDocsUrl = require('../util/getDocsUrl')
+
 module.exports = {
     meta: {
         docs: {
-            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/matches-prop-shorthand.md'
+            url: getDocsUrl('matches-prop-shorthand.md')
         },
         schema: [{
             enum: ['always', 'never']

--- a/src/rules/matches-shorthand.js
+++ b/src/rules/matches-shorthand.js
@@ -7,10 +7,12 @@
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+const getDocsUrl = require('../util/getDocsUrl')
+
 module.exports = {
     meta: {
         docs: {
-            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/matches-shorthand.md'
+            url: getDocsUrl('matches-shorthand.md')
         },
         schema: [{
             enum: ['always', 'never']

--- a/src/rules/no-commit.js
+++ b/src/rules/no-commit.js
@@ -7,10 +7,12 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
+const getDocsUrl = require('../util/getDocsUrl')
+
 module.exports = {
     meta: {
         docs: {
-            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/no-commit.md'
+            url: getDocsUrl('no-commit.md')
         }
     },
 

--- a/src/rules/no-double-unwrap.js
+++ b/src/rules/no-double-unwrap.js
@@ -7,10 +7,12 @@
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+const getDocsUrl = require('../util/getDocsUrl')
+
 module.exports = {
     meta: {
         docs: {
-            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/no-double-unwrap.md'
+            url: getDocsUrl('no-double-unwrap.md')
         },
         fixable: "code"
     },

--- a/src/rules/no-extra-args.js
+++ b/src/rules/no-extra-args.js
@@ -7,10 +7,12 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
+const getDocsUrl = require('../util/getDocsUrl')
+
 module.exports = {
     meta: {
         docs: {
-            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/no-extra-args.md'
+            url: getDocsUrl('no-extra-args.md')
         }
     },
 

--- a/src/rules/no-unbound-this.js
+++ b/src/rules/no-unbound-this.js
@@ -7,10 +7,12 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
+const getDocsUrl = require('../util/getDocsUrl')
+
 module.exports = {
     meta: {
         docs: {
-            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/no-unbound-this.md'
+            url: getDocsUrl('no-unbound-this.md')
         }
     },
 

--- a/src/rules/path-style.js
+++ b/src/rules/path-style.js
@@ -7,10 +7,12 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
+const getDocsUrl = require('../util/getDocsUrl')
+
 module.exports = {
     meta: {
         docs: {
-            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/path-style.md'
+            url: getDocsUrl('path-style.md')
         },
         schema: [{
             enum: ['as-needed', 'array', 'string']

--- a/src/rules/prefer-compact.js
+++ b/src/rules/prefer-compact.js
@@ -7,10 +7,12 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
+const getDocsUrl = require('../util/getDocsUrl')
+
 module.exports = {
     meta: {
         docs: {
-            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/prefer-compact.md'
+            url: getDocsUrl('prefer-compact.md')
         }
     },
 

--- a/src/rules/prefer-constant.js
+++ b/src/rules/prefer-constant.js
@@ -7,10 +7,12 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
+const getDocsUrl = require('../util/getDocsUrl')
+
 module.exports = {
     meta: {
         docs: {
-            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/prefer-constant.md'
+            url: getDocsUrl('prefer-constant.md')
         },
 
         schema: [{

--- a/src/rules/prefer-filter.js
+++ b/src/rules/prefer-filter.js
@@ -7,10 +7,12 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
+const getDocsUrl = require('../util/getDocsUrl')
+
 module.exports = {
     meta: {
         docs: {
-            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/prefer-filter.md'
+            url: getDocsUrl('prefer-filter.md')
         },
         schema: [{
             type: 'integer'

--- a/src/rules/prefer-flat-map.js
+++ b/src/rules/prefer-flat-map.js
@@ -7,10 +7,12 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
+const getDocsUrl = require('../util/getDocsUrl')
+
 module.exports = {
     meta: {
         docs: {
-            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/prefer-flat-map.md'
+            url: getDocsUrl('prefer-flat-map.md')
         }
     },
 

--- a/src/rules/prefer-get.js
+++ b/src/rules/prefer-get.js
@@ -7,10 +7,12 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
+const getDocsUrl = require('../util/getDocsUrl')
+
 module.exports = {
     meta: {
         docs: {
-            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/prefer-get.md'
+            url: getDocsUrl('prefer-get.md')
         },
         schema: [{
             type: 'integer',

--- a/src/rules/prefer-includes.js
+++ b/src/rules/prefer-includes.js
@@ -7,10 +7,12 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
+const getDocsUrl = require('../util/getDocsUrl')
+
 module.exports = {
     meta: {
         docs: {
-            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/prefer-includes.md'
+            url: getDocsUrl('prefer-includes.md')
         },
         schema: [{
             type: 'object',

--- a/src/rules/prefer-invoke-map.js
+++ b/src/rules/prefer-invoke-map.js
@@ -7,10 +7,12 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
+const getDocsUrl = require('../util/getDocsUrl')
+
 module.exports = {
     meta: {
         docs: {
-            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/prefer-invoke-map.md'
+            url: getDocsUrl('prefer-invoke-map.md')
         }
     },
 

--- a/src/rules/prefer-is-nil.js
+++ b/src/rules/prefer-is-nil.js
@@ -7,10 +7,12 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
+const getDocsUrl = require('../util/getDocsUrl')
+
 module.exports = {
     meta: {
         docs: {
-            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/prefer-is-nil.md'
+            url: getDocsUrl('prefer-is-nil.md')
         }
     },
 

--- a/src/rules/prefer-lodash-chain.js
+++ b/src/rules/prefer-lodash-chain.js
@@ -7,10 +7,12 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
+const getDocsUrl = require('../util/getDocsUrl')
+
 module.exports = {
     meta: {
         docs: {
-            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/prefer-lodash-chain.md'
+            url: getDocsUrl('prefer-lodash-chain.md')
         }
     },
 

--- a/src/rules/prefer-lodash-method.js
+++ b/src/rules/prefer-lodash-method.js
@@ -7,10 +7,12 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
+const getDocsUrl = require('../util/getDocsUrl')
+
 module.exports = {
     meta: {
         docs: {
-            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/prefer-lodash-method.md'
+            url: getDocsUrl('prefer-lodash-method.md')
         },
         schema: [{
             type: 'object',

--- a/src/rules/prefer-lodash-typecheck.js
+++ b/src/rules/prefer-lodash-typecheck.js
@@ -7,10 +7,12 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
+const getDocsUrl = require('../util/getDocsUrl')
+
 module.exports = {
     meta: {
         docs: {
-            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/prefer-lodash-typecheck.md'
+            url: getDocsUrl('prefer-lodash-typecheck.md')
         }
     },
 

--- a/src/rules/prefer-map.js
+++ b/src/rules/prefer-map.js
@@ -7,10 +7,12 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
+const getDocsUrl = require('../util/getDocsUrl')
+
 module.exports = {
     meta: {
         docs: {
-            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/prefer-map.md'
+            url: getDocsUrl('prefer-map.md')
         }
     },
 

--- a/src/rules/prefer-matches.js
+++ b/src/rules/prefer-matches.js
@@ -7,10 +7,12 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
+const getDocsUrl = require('../util/getDocsUrl')
+
 module.exports = {
     meta: {
         docs: {
-            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/prefer-matches.md'
+            url: getDocsUrl('prefer-matches.md')
         },
         schema: [{
             type: 'integer',

--- a/src/rules/prefer-noop.js
+++ b/src/rules/prefer-noop.js
@@ -7,10 +7,12 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
+const getDocsUrl = require('../util/getDocsUrl')
+
 module.exports = {
     meta: {
         docs: {
-            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/prefer-noop.md'
+            url: getDocsUrl('prefer-noop.md')
         }
     },
 

--- a/src/rules/prefer-over-quantifier.js
+++ b/src/rules/prefer-over-quantifier.js
@@ -7,10 +7,12 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
+const getDocsUrl = require('../util/getDocsUrl')
+
 module.exports = {
     meta: {
         docs: {
-            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/prefer-over-quantifier.md'
+            url: getDocsUrl('prefer-over-quantifier.md')
         }
     },
 

--- a/src/rules/prefer-reject.js
+++ b/src/rules/prefer-reject.js
@@ -7,10 +7,12 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
+const getDocsUrl = require('../util/getDocsUrl')
+
 module.exports = {
     meta: {
         docs: {
-            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/prefer-reject.md'
+            url: getDocsUrl('prefer-reject.md')
         },
         schema: [{
             type: 'integer'

--- a/src/rules/prefer-some.js
+++ b/src/rules/prefer-some.js
@@ -7,10 +7,12 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
+const getDocsUrl = require('../util/getDocsUrl')
+
 module.exports = {
     meta: {
         docs: {
-            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/prefer-some.md'
+            url: getDocsUrl('prefer-some.md')
         },
         schema: [{
             type: 'object',

--- a/src/rules/prefer-startswith.js
+++ b/src/rules/prefer-startswith.js
@@ -7,10 +7,12 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
+const getDocsUrl = require('../util/getDocsUrl')
+
 module.exports = {
     meta: {
         docs: {
-            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/prefer-startswith.md'
+            url: getDocsUrl('prefer-startswith.md')
         }
     },
 

--- a/src/rules/prefer-thru.js
+++ b/src/rules/prefer-thru.js
@@ -7,10 +7,12 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
+const getDocsUrl = require('../util/getDocsUrl')
+
 module.exports = {
     meta: {
         docs: {
-            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/prefer-thru.md'
+            url: getDocsUrl('prefer-thru.md')
         }
     },
 

--- a/src/rules/prefer-times.js
+++ b/src/rules/prefer-times.js
@@ -7,10 +7,12 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
+const getDocsUrl = require('../util/getDocsUrl')
+
 module.exports = {
     meta: {
         docs: {
-            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/prefer-times.md'
+            url: getDocsUrl('prefer-times.md')
         }
     },
 

--- a/src/rules/prefer-wrapper-method.js
+++ b/src/rules/prefer-wrapper-method.js
@@ -7,10 +7,12 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
+const getDocsUrl = require('../util/getDocsUrl')
+
 module.exports = {
     meta: {
         docs: {
-            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/prefer-wrapper-method.md'
+            url: getDocsUrl('prefer-wrapper-method.md')
         }
     },
 

--- a/src/rules/preferred-alias.js
+++ b/src/rules/preferred-alias.js
@@ -7,10 +7,12 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
+const getDocsUrl = require('../util/getDocsUrl')
+
 module.exports = {
     meta: {
         docs: {
-            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/preferred-alias.md'
+            url: getDocsUrl('preferred-alias.md')
         }
     },
 

--- a/src/rules/prop-shorthand.js
+++ b/src/rules/prop-shorthand.js
@@ -7,11 +7,12 @@
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+const getDocsUrl = require('../util/getDocsUrl')
 
 module.exports = {
     meta: {
         docs: {
-            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/prop-shorthand.md'
+            url: getDocsUrl('prop-shorthand.md')
         },
         schema: [{
             enum: ['always', 'never']

--- a/src/rules/unwrap.js
+++ b/src/rules/unwrap.js
@@ -7,10 +7,12 @@
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+const getDocsUrl = require('../util/getDocsUrl')
+
 module.exports = {
     meta: {
         docs: {
-            url: 'https://github.com/wix/eslint-plugin-lodash/tree/master/docs/rules/unwrap.md'
+            url: getDocsUrl('unwrap.md')
         }
     },
 

--- a/src/util/getDocsUrl.js
+++ b/src/util/getDocsUrl.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const pkg = require('../../package')
+
+const REPO_URL = 'https://github.com/wix/eslint-plugin-lodash'
+
+/**
+* Generates the URL to documentation for the given rule name. It uses the
+* package version to build the link to a tagged version of the
+* documentation file.
+*
+* @param {string} ruleName - Name of the eslint rule
+* @returns {string} URL to the documentation for the given rule
+*/
+module.exports = function getDocsUrl(ruleName) {
+   return `${REPO_URL}/blob/v${pkg.version}/docs/rules/${ruleName}.md`
+}

--- a/tests/lib/util/getDocsUrl.js
+++ b/tests/lib/util/getDocsUrl.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const assert = require('assert')
+const pkg = require('../../../package')
+const getDocsUrl = require('../../../src/util/getDocsUrl')
+
+describe('getDocsUrl', () => {
+    it('returns the URL of the a named rule\'s documentation', () => {
+        const url = `https://github.com/wix/eslint-plugin-lodash/blob/v${pkg.version}/docs/rules/foo.md`
+        assert.strictEqual(getDocsUrl('foo'), url)
+    })
+})


### PR DESCRIPTION
This adds a utility function and uses the version present in package.json for generating the URL to tagged version of the rule documentation. I think this is good because the documentation will match the version the user has installed. This way, even if a rule is changed or removed in the future, the user can find the documentation with ease.