### PR TITLE
Remove `.md` from rulename used to build docs URL

### DIFF
--- a/src/rules/callback-binding.js
+++ b/src/rules/callback-binding.js
@@ -12,7 +12,7 @@ const getDocsUrl = require('../util/getDocsUrl')
 module.exports = {
     meta: {
         docs: {
-            url: getDocsUrl('callback-binding.md')
+            url: getDocsUrl('callback-binding')
         }
     },
 

--- a/src/rules/chain-style.js
+++ b/src/rules/chain-style.js
@@ -12,7 +12,7 @@ const getDocsUrl = require('../util/getDocsUrl')
 module.exports = {
     meta: {
         docs: {
-            url: getDocsUrl('chain-style.md')
+            url: getDocsUrl('chain-style')
         },
         schema: [{
             enum: ['as-needed', 'implicit', 'explicit']

--- a/src/rules/chaining.js
+++ b/src/rules/chaining.js
@@ -12,7 +12,7 @@ const getDocsUrl = require('../util/getDocsUrl')
 module.exports = {
     meta: {
         docs: {
-            url: getDocsUrl('chaining.md')
+            url: getDocsUrl('chaining')
         },
         schema: [{
             enum: ['always', 'never']

--- a/src/rules/collection-method-value.js
+++ b/src/rules/collection-method-value.js
@@ -12,7 +12,7 @@ const getDocsUrl = require('../util/getDocsUrl')
 module.exports = {
     meta: {
         docs: {
-            url: getDocsUrl('collection-method-value.md')
+            url: getDocsUrl('collection-method-value')
         }
     },
 

--- a/src/rules/collection-return.js
+++ b/src/rules/collection-return.js
@@ -12,7 +12,7 @@ const getDocsUrl = require('../util/getDocsUrl')
 module.exports = {
     meta: {
         docs: {
-            url: getDocsUrl('collection-return.md')
+            url: getDocsUrl('collection-return')
         }
     },
 

--- a/src/rules/consistent-compose.js
+++ b/src/rules/consistent-compose.js
@@ -14,7 +14,7 @@ const possibleDirections = ['pipe', 'compose', 'flow', 'flowRight']
 module.exports = {
     meta: {
         docs: {
-            url: getDocsUrl('consistent-compose.md')
+            url: getDocsUrl('consistent-compose')
         },
         schema: [{
             enum: possibleDirections

--- a/src/rules/identity-shorthand.js
+++ b/src/rules/identity-shorthand.js
@@ -12,7 +12,7 @@ const getDocsUrl = require('../util/getDocsUrl')
 module.exports = {
     meta: {
         docs: {
-            url: getDocsUrl('identity-shorthand.md')
+            url: getDocsUrl('identity-shorthand')
         },
         schema: [{
             enum: ['always', 'never']

--- a/src/rules/import-scope.js
+++ b/src/rules/import-scope.js
@@ -33,7 +33,7 @@ const allImportsAreOfType = (node, types) => every(node.specifiers, specifier =>
 module.exports = {
     meta: {
         docs: {
-            url: getDocsUrl('import-scope.md')
+            url: getDocsUrl('import-scope')
         },
         schema: [{
             enum: ['method', 'member', 'full', 'method-package']

--- a/src/rules/matches-prop-shorthand.js
+++ b/src/rules/matches-prop-shorthand.js
@@ -12,7 +12,7 @@ const getDocsUrl = require('../util/getDocsUrl')
 module.exports = {
     meta: {
         docs: {
-            url: getDocsUrl('matches-prop-shorthand.md')
+            url: getDocsUrl('matches-prop-shorthand')
         },
         schema: [{
             enum: ['always', 'never']

--- a/src/rules/matches-shorthand.js
+++ b/src/rules/matches-shorthand.js
@@ -12,7 +12,7 @@ const getDocsUrl = require('../util/getDocsUrl')
 module.exports = {
     meta: {
         docs: {
-            url: getDocsUrl('matches-shorthand.md')
+            url: getDocsUrl('matches-shorthand')
         },
         schema: [{
             enum: ['always', 'never']

--- a/src/rules/no-commit.js
+++ b/src/rules/no-commit.js
@@ -12,7 +12,7 @@ const getDocsUrl = require('../util/getDocsUrl')
 module.exports = {
     meta: {
         docs: {
-            url: getDocsUrl('no-commit.md')
+            url: getDocsUrl('no-commit')
         }
     },
 

--- a/src/rules/no-double-unwrap.js
+++ b/src/rules/no-double-unwrap.js
@@ -12,7 +12,7 @@ const getDocsUrl = require('../util/getDocsUrl')
 module.exports = {
     meta: {
         docs: {
-            url: getDocsUrl('no-double-unwrap.md')
+            url: getDocsUrl('no-double-unwrap')
         },
         fixable: "code"
     },

--- a/src/rules/no-extra-args.js
+++ b/src/rules/no-extra-args.js
@@ -12,7 +12,7 @@ const getDocsUrl = require('../util/getDocsUrl')
 module.exports = {
     meta: {
         docs: {
-            url: getDocsUrl('no-extra-args.md')
+            url: getDocsUrl('no-extra-args')
         }
     },
 

--- a/src/rules/no-unbound-this.js
+++ b/src/rules/no-unbound-this.js
@@ -12,7 +12,7 @@ const getDocsUrl = require('../util/getDocsUrl')
 module.exports = {
     meta: {
         docs: {
-            url: getDocsUrl('no-unbound-this.md')
+            url: getDocsUrl('no-unbound-this')
         }
     },
 

--- a/src/rules/path-style.js
+++ b/src/rules/path-style.js
@@ -12,7 +12,7 @@ const getDocsUrl = require('../util/getDocsUrl')
 module.exports = {
     meta: {
         docs: {
-            url: getDocsUrl('path-style.md')
+            url: getDocsUrl('path-style')
         },
         schema: [{
             enum: ['as-needed', 'array', 'string']

--- a/src/rules/prefer-compact.js
+++ b/src/rules/prefer-compact.js
@@ -12,7 +12,7 @@ const getDocsUrl = require('../util/getDocsUrl')
 module.exports = {
     meta: {
         docs: {
-            url: getDocsUrl('prefer-compact.md')
+            url: getDocsUrl('prefer-compact')
         }
     },
 

--- a/src/rules/prefer-constant.js
+++ b/src/rules/prefer-constant.js
@@ -12,7 +12,7 @@ const getDocsUrl = require('../util/getDocsUrl')
 module.exports = {
     meta: {
         docs: {
-            url: getDocsUrl('prefer-constant.md')
+            url: getDocsUrl('prefer-constant')
         },
 
         schema: [{

--- a/src/rules/prefer-filter.js
+++ b/src/rules/prefer-filter.js
@@ -12,7 +12,7 @@ const getDocsUrl = require('../util/getDocsUrl')
 module.exports = {
     meta: {
         docs: {
-            url: getDocsUrl('prefer-filter.md')
+            url: getDocsUrl('prefer-filter')
         },
         schema: [{
             type: 'integer'

--- a/src/rules/prefer-flat-map.js
+++ b/src/rules/prefer-flat-map.js
@@ -12,7 +12,7 @@ const getDocsUrl = require('../util/getDocsUrl')
 module.exports = {
     meta: {
         docs: {
-            url: getDocsUrl('prefer-flat-map.md')
+            url: getDocsUrl('prefer-flat-map')
         }
     },
 

--- a/src/rules/prefer-get.js
+++ b/src/rules/prefer-get.js
@@ -12,7 +12,7 @@ const getDocsUrl = require('../util/getDocsUrl')
 module.exports = {
     meta: {
         docs: {
-            url: getDocsUrl('prefer-get.md')
+            url: getDocsUrl('prefer-get')
         },
         schema: [{
             type: 'integer',

--- a/src/rules/prefer-includes.js
+++ b/src/rules/prefer-includes.js
@@ -12,7 +12,7 @@ const getDocsUrl = require('../util/getDocsUrl')
 module.exports = {
     meta: {
         docs: {
-            url: getDocsUrl('prefer-includes.md')
+            url: getDocsUrl('prefer-includes')
         },
         schema: [{
             type: 'object',

--- a/src/rules/prefer-invoke-map.js
+++ b/src/rules/prefer-invoke-map.js
@@ -12,7 +12,7 @@ const getDocsUrl = require('../util/getDocsUrl')
 module.exports = {
     meta: {
         docs: {
-            url: getDocsUrl('prefer-invoke-map.md')
+            url: getDocsUrl('prefer-invoke-map')
         }
     },
 

--- a/src/rules/prefer-is-nil.js
+++ b/src/rules/prefer-is-nil.js
@@ -12,7 +12,7 @@ const getDocsUrl = require('../util/getDocsUrl')
 module.exports = {
     meta: {
         docs: {
-            url: getDocsUrl('prefer-is-nil.md')
+            url: getDocsUrl('prefer-is-nil')
         }
     },
 

--- a/src/rules/prefer-lodash-chain.js
+++ b/src/rules/prefer-lodash-chain.js
@@ -12,7 +12,7 @@ const getDocsUrl = require('../util/getDocsUrl')
 module.exports = {
     meta: {
         docs: {
-            url: getDocsUrl('prefer-lodash-chain.md')
+            url: getDocsUrl('prefer-lodash-chain')
         }
     },
 

--- a/src/rules/prefer-lodash-method.js
+++ b/src/rules/prefer-lodash-method.js
@@ -12,7 +12,7 @@ const getDocsUrl = require('../util/getDocsUrl')
 module.exports = {
     meta: {
         docs: {
-            url: getDocsUrl('prefer-lodash-method.md')
+            url: getDocsUrl('prefer-lodash-method')
         },
         schema: [{
             type: 'object',

--- a/src/rules/prefer-lodash-typecheck.js
+++ b/src/rules/prefer-lodash-typecheck.js
@@ -12,7 +12,7 @@ const getDocsUrl = require('../util/getDocsUrl')
 module.exports = {
     meta: {
         docs: {
-            url: getDocsUrl('prefer-lodash-typecheck.md')
+            url: getDocsUrl('prefer-lodash-typecheck')
         }
     },
 

--- a/src/rules/prefer-map.js
+++ b/src/rules/prefer-map.js
@@ -12,7 +12,7 @@ const getDocsUrl = require('../util/getDocsUrl')
 module.exports = {
     meta: {
         docs: {
-            url: getDocsUrl('prefer-map.md')
+            url: getDocsUrl('prefer-map')
         }
     },
 

--- a/src/rules/prefer-matches.js
+++ b/src/rules/prefer-matches.js
@@ -12,7 +12,7 @@ const getDocsUrl = require('../util/getDocsUrl')
 module.exports = {
     meta: {
         docs: {
-            url: getDocsUrl('prefer-matches.md')
+            url: getDocsUrl('prefer-matches')
         },
         schema: [{
             type: 'integer',

--- a/src/rules/prefer-noop.js
+++ b/src/rules/prefer-noop.js
@@ -12,7 +12,7 @@ const getDocsUrl = require('../util/getDocsUrl')
 module.exports = {
     meta: {
         docs: {
-            url: getDocsUrl('prefer-noop.md')
+            url: getDocsUrl('prefer-noop')
         }
     },
 

--- a/src/rules/prefer-over-quantifier.js
+++ b/src/rules/prefer-over-quantifier.js
@@ -12,7 +12,7 @@ const getDocsUrl = require('../util/getDocsUrl')
 module.exports = {
     meta: {
         docs: {
-            url: getDocsUrl('prefer-over-quantifier.md')
+            url: getDocsUrl('prefer-over-quantifier')
         }
     },
 

--- a/src/rules/prefer-reject.js
+++ b/src/rules/prefer-reject.js
@@ -12,7 +12,7 @@ const getDocsUrl = require('../util/getDocsUrl')
 module.exports = {
     meta: {
         docs: {
-            url: getDocsUrl('prefer-reject.md')
+            url: getDocsUrl('prefer-reject')
         },
         schema: [{
             type: 'integer'

--- a/src/rules/prefer-some.js
+++ b/src/rules/prefer-some.js
@@ -12,7 +12,7 @@ const getDocsUrl = require('../util/getDocsUrl')
 module.exports = {
     meta: {
         docs: {
-            url: getDocsUrl('prefer-some.md')
+            url: getDocsUrl('prefer-some')
         },
         schema: [{
             type: 'object',

--- a/src/rules/prefer-startswith.js
+++ b/src/rules/prefer-startswith.js
@@ -12,7 +12,7 @@ const getDocsUrl = require('../util/getDocsUrl')
 module.exports = {
     meta: {
         docs: {
-            url: getDocsUrl('prefer-startswith.md')
+            url: getDocsUrl('prefer-startswith')
         }
     },
 

--- a/src/rules/prefer-thru.js
+++ b/src/rules/prefer-thru.js
@@ -12,7 +12,7 @@ const getDocsUrl = require('../util/getDocsUrl')
 module.exports = {
     meta: {
         docs: {
-            url: getDocsUrl('prefer-thru.md')
+            url: getDocsUrl('prefer-thru')
         }
     },
 

--- a/src/rules/prefer-times.js
+++ b/src/rules/prefer-times.js
@@ -12,7 +12,7 @@ const getDocsUrl = require('../util/getDocsUrl')
 module.exports = {
     meta: {
         docs: {
-            url: getDocsUrl('prefer-times.md')
+            url: getDocsUrl('prefer-times')
         }
     },
 

--- a/src/rules/prefer-wrapper-method.js
+++ b/src/rules/prefer-wrapper-method.js
@@ -12,7 +12,7 @@ const getDocsUrl = require('../util/getDocsUrl')
 module.exports = {
     meta: {
         docs: {
-            url: getDocsUrl('prefer-wrapper-method.md')
+            url: getDocsUrl('prefer-wrapper-method')
         }
     },
 

--- a/src/rules/preferred-alias.js
+++ b/src/rules/preferred-alias.js
@@ -12,7 +12,7 @@ const getDocsUrl = require('../util/getDocsUrl')
 module.exports = {
     meta: {
         docs: {
-            url: getDocsUrl('preferred-alias.md')
+            url: getDocsUrl('preferred-alias')
         },
         schema: [{
             type: 'object',

--- a/src/rules/prop-shorthand.js
+++ b/src/rules/prop-shorthand.js
@@ -12,7 +12,7 @@ const getDocsUrl = require('../util/getDocsUrl')
 module.exports = {
     meta: {
         docs: {
-            url: getDocsUrl('prop-shorthand.md')
+            url: getDocsUrl('prop-shorthand')
         },
         schema: [{
             enum: ['always', 'never']

--- a/src/rules/unwrap.js
+++ b/src/rules/unwrap.js
@@ -12,7 +12,7 @@ const getDocsUrl = require('../util/getDocsUrl')
 module.exports = {
     meta: {
         docs: {
-            url: getDocsUrl('unwrap.md')
+            url: getDocsUrl('unwrap')
         }
     },
 


### PR DESCRIPTION
Passing `rule-name.md` as the rulename was resulting in the URL having the extension twice because the function `getDocsUrl` adds the extension as well when building the URL (ex: `https://github.com/wix/eslint-plugin-lodash/blob/v2.5.1/docs/rules/prefer-some.md.md` for rule `prefer-some`). Apologies for the inadvertent issue.