### PR TITLE
Prevent prefer-lodash-method error on chain() in combination with member import

### DIFF
--- a/src/util/LodashContext.js
+++ b/src/util/LodashContext.js
@@ -33,6 +33,10 @@ module.exports = class {
                                 break
                             case 'ImportSpecifier':
                                 self.methods[spec.local.name] = spec.imported.name
+
+                                if (spec.imported.name === 'chain') {
+                                    self.general[spec.local.name] = true
+                                }
                                 break
                         }
                     })
@@ -113,12 +117,21 @@ module.exports = class {
     }
 
     /**
+     * Returns whether the node is chain start imported as member, chain()... import { chain } from 'lodash'
+     * @param node
+     * @returns {boolean}
+     */
+    isMemberImportedChainStart(node) {
+        return node.callee.name === 'chain' && this.isImportedLodash(node.callee)
+    }
+
+    /**
      * Returns whether the node is a Lodash chain start, implicit or explicit
      * @param node
      * @returns {*|boolean|boolean|undefined}
      */
     isLodashChainStart(node) {
-        return node && node.type === 'CallExpression' && (this.isImplicitChainStart(node) || this.isExplicitChainStart(node))
+        return node && node.type === 'CallExpression' && (this.isImplicitChainStart(node) || this.isExplicitChainStart(node) || this.isMemberImportedChainStart(node))
     }
 
     /**


### PR DESCRIPTION
As described in #186 it seems the plugin marks methods on chain with prefer-lodash-method error when `chain` is imported as member `import { chain } from 'lodash'`. 

This PR fixes this by checking module imports for chain, registering this as general module, and check if a `chain()` call refers to the import from lodash.

Unfortunately I was not able to cover this change with a test because it requires to test if `chain` is an imported member from lodash. Hints how to cover this welcome!