### PR TITLE
fix full lodash import trailing slash

### DIFF
--- a/src/util/importUtil.js
+++ b/src/util/importUtil.js
@@ -8,7 +8,7 @@ function getNameFromCjsRequire(init) {
 }
 
 
-const isFullLodashImport = str => /^lodash(-es)?$/.test(str)
+const isFullLodashImport = str => /^lodash(-es)?(\/)?$/.test(str)
 const getMethodImportFromName = str => {
     const match = /^lodash(-es\/|[./])(?!fp)(\w+)$/.exec(str)
     return match && match[2]

--- a/tests/lib/rules/import-scope.js
+++ b/tests/lib/rules/import-scope.js
@@ -103,11 +103,13 @@ const testCases = {
         method: {
             require: [
                 "const _ = require('lodash')",
+                "const _ = require('lodash/')",
                 "const {map} = require('lodash')",
                 "const map = require('lodash.map')"
             ],
             import: [
                 "import _ from 'lodash'",
+                "import _ from 'lodash/'",
                 "import {map} from 'lodash'",
                 "import * as _ from 'lodash'",
                 "import map from 'lodash.map'"


### PR DESCRIPTION
Apparently, using `import _ from "lodash/"` (notice the trailing `/`) is a way to bypass the single import method rule. I've added an optional match on the regex.

This is what is happening:
```
/*eslint lodash/import-scope: [2, "method"]*/
import _ from "lodash/"
```
whereas 
```
/*eslint lodash/import-scope: [2, "method"]*/
import _ from "lodash"
```
throws an error / warning as expected


