### PR TITLE
Rule path-style with --fix for strings that cannot be used as canBeDo…

### DIFF
--- a/src/rules/path-style.js
+++ b/src/rules/path-style.js
@@ -93,7 +93,7 @@ module.exports = {
 
         function convertToStringStyleWithoutVariables(node) {
             return `'${node.elements
-                .map(el => canBeDotNotation(el) ? `.${el.value}` : `[${el.value}]`)
+                .map(el => canBeDotNotation(el) ? `.${el.value}` : `["${el.value}"]`)
                 .join('')
                 .replace(/^\./, '')}'`
         }
@@ -124,7 +124,7 @@ module.exports = {
             'as-needed'(node) {
                 if (isArrayOfLiterals(node)) {
                     context.report({
-                        node, 
+                        node,
                         messageId: 'stringForSimple',
                         fix(fixer) {
                             return fixer.replaceText(node, convertToStringStyle(node, false))
@@ -132,12 +132,12 @@ module.exports = {
                     })
                 } else if (isStringConcatWithVariableProps(node)) {
                     context.report({
-                        node, 
+                        node,
                         messageId: 'arrayForVars'
                     })
                 } else if (isTemplateStringWithVariableProps(node)) {
                     context.report({
-                        node, 
+                        node,
                         messageId: 'arrayForVars'
                     })
                 }
@@ -145,7 +145,7 @@ module.exports = {
             array(node) {
                 if (isLiteral(node)) {
                     context.report({
-                        node, 
+                        node,
                         messageId: 'array',
                         fix(fixer) {
                             return fixer.replaceText(node, `[${toPath(node.value)
@@ -155,7 +155,7 @@ module.exports = {
                     })
                 } else if (isTemplateLiteral(node)) {
                     context.report({
-                        node, 
+                        node,
                         messageId: 'array'
                     })
                 }
@@ -163,7 +163,7 @@ module.exports = {
             string(node) {
                 if (isArrayExpression(node)) {
                     context.report({
-                        node, 
+                        node,
                         messageId: 'string',
                         fix(fixer) {
                             return fixer.replaceText(node, convertToStringStyle(node, true))

--- a/tests/lib/rules/path-style.js
+++ b/tests/lib/rules/path-style.js
@@ -33,7 +33,11 @@ ruleTester.run('path-style', rule, {
     }, {
         code: "_.invoke(x, ['a', 'some-value'])",
         errors: [{messageId: 'stringForSimple'}],
-        output: "_.invoke(x, 'a[some-value]')"
+        output: "_.invoke(x, 'a[\"some-value\"]')"
+    }, {
+        code: "_.invoke(x, ['a', 'b.c', 'd'])",
+        errors: [{messageId: 'stringForSimple'}],
+        output: "_.invoke(x, 'a[\"b.c\"].d')"
     }, {
         code: "_(x).invoke(['a']).filter(f).value()",
         errors: [{messageId: 'stringForSimple'}],


### PR DESCRIPTION
…tNotation has a bug, missing quotes