### PR TITLE
Improve test coverage for matches-shorthand & matches-prop-shorthand. Fix incorrect iteratee & shorthand method data uncovered thereby.

### DIFF
--- a/src/util/methodDataByVersion/3.js
+++ b/src/util/methodDataByVersion/3.js
@@ -360,7 +360,7 @@ module.exports = {
     findLast: {
         aliases: [],
         wrapper: false,
-        shorthand: false,
+        shorthand: true,
         chainable: false,
         iteratee: true,
         args: 3
@@ -1198,7 +1198,7 @@ module.exports = {
     result: {
         aliases: [],
         wrapper: false,
-        shorthand: true,
+        shorthand: false,
         chainable: false,
         iteratee: false,
         args: 3
@@ -1318,7 +1318,7 @@ module.exports = {
         wrapper: false,
         shorthand: true,
         chainable: true,
-        iteratee: false
+        iteratee: true
     },
     sortedIndex: {
         aliases: [],

--- a/src/util/methodDataByVersion/4.js
+++ b/src/util/methodDataByVersion/4.js
@@ -336,7 +336,7 @@ module.exports = {
         wrapper: false,
         shorthand: true,
         chainable: true,
-        iteratee: false
+        iteratee: true
     },
     differenceWith: {
         aliases: [],
@@ -468,7 +468,7 @@ module.exports = {
     findLast: {
         aliases: [],
         wrapper: false,
-        shorthand: false,
+        shorthand: true,
         chainable: false,
         iteratee: true,
         args: 3
@@ -760,7 +760,7 @@ module.exports = {
         wrapper: false,
         shorthand: true,
         chainable: true,
-        iteratee: false
+        iteratee: true
     },
     intersectionWith: {
         aliases: [],
@@ -1435,14 +1435,14 @@ module.exports = {
         wrapper: false,
         shorthand: true,
         chainable: true,
-        iteratee: false
+        iteratee: true
     },
     overSome: {
         aliases: [],
         wrapper: false,
         shorthand: true,
         chainable: true,
-        iteratee: false
+        iteratee: true
     },
     pad: {
         aliases: [],
@@ -2222,7 +2222,7 @@ module.exports = {
         wrapper: false,
         shorthand: true,
         chainable: true,
-        iteratee: false
+        iteratee: true
     },
     unionWith: {
         aliases: [],

--- a/tests/lib/rules/matches-shorthand.js
+++ b/tests/lib/rules/matches-shorthand.js
@@ -4,9 +4,12 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
+const _ = require('lodash')
 const rule = require('../../../src/rules/matches-shorthand')
 const ruleTesterUtil = require('../testUtil/ruleTesterUtil')
+const {methodSupportsShorthand, getIterateeIndex} = require('../../../src/util/methodDataUtil')
 
+const getMethodData = version => require(`../../../src/util/methodDataByVersion/${version}`)
 
 // ------------------------------------------------------------------------------
 // Tests
@@ -16,6 +19,29 @@ const ruleTester = ruleTesterUtil.getRuleTester()
 const messages = {
     always: 'Prefer matches syntax',
     never: 'Do not use matches syntax'
+}
+
+const methodsThatSupportShorthand = _([3, 4])
+    .map(version =>
+        _(getMethodData(version))
+            .map((data, method) => ({method, version, iterateeIndex: getIterateeIndex(version, method)}))
+            .filter(({method}) => methodSupportsShorthand(version, method))
+            .value()
+    )
+    .flatten()
+    .value()
+
+const getExampleCodeWithShorthand = ({method, iterateeIndex}) => {
+    switch (iterateeIndex) {
+        case 1:
+            return `_.${method}(arr, {b: {c: compId}});`
+        case 2:
+            return `_.${method}(arr, foo, {b: {c: compId}});`
+        case 3:
+            return `_.${method}(arr, foo, bar, {b: {c: compId}});`
+        default:
+            throw new Error(`${iterateeIndex} for ${method} not supported`)
+    }
 }
 
 const {withDefaultPragma} = require('../testUtil/optionsUtil')
@@ -34,7 +60,14 @@ ruleTester.run('matches-shorthand', rule, {
             options: ['always', 1, true, {onlyLiterals: true}]
         }
     ].map(withDefaultPragma),
-    invalid: [{
+    invalid: methodsThatSupportShorthand.map(({version, method, iterateeIndex}) => ({
+        code: getExampleCodeWithShorthand({method, iterateeIndex}),
+        options: ['never'],
+        errors: [{message: messages.never}],
+        settings: {
+            lodash: {version}
+        }
+    })).concat([{
         code: 'var isPublic = _.find([], function (i) { return i.id === id; });',
         errors: [{message: messages.always, column: 27}]
     }, {
@@ -60,12 +93,8 @@ ruleTester.run('matches-shorthand', rule, {
         options: ['always', 3, true],
         errors: [{message: messages.always, column: 22}]
     }, {
-        code: '_.findLastIndex(arr, {b: {c: compId}});',
-        options: ['never'],
-        errors: [{message: messages.never, column: 22}]
-    }, {
         code: 'var isPublic = _.find([], function(i) { return i.id === 3 && i.a === "b"; });',
         options: ['always', 1, true, {onlyLiterals: true}],
         errors: [{message: messages.always, column: 27}]
-    }].map(withDefaultPragma)
+    }]).map(withDefaultPragma)
 })


### PR DESCRIPTION
#### Improve coverage for `matches-shorthand` and `matches-prop-shorthand` rules

Automatically generate test cases for the `never` option for these two rules by mapping over the lodash methods which support a shorthand iteratee argument, and testing that with the `never` option enabled the use of shorthand is forbidden as expected.

This can uncover incorrect method data more effectively than a handful of arbitrary picked test cases.

The same could be done to test the positive (non-`never`) case, etc. but I didn't want to sink too much time into this before making sure this project's maintainers were on board with this approach.

#### Fix miscellaneous incorrect `shorthand` and `iteratee` method data values

The above test coverage improvements uncovered various bits of method data that were seemingly incorrect. I cross-referenced each of these with lodash docs for the corresponding version.