### PR TITLE
fix: Autofix for paths with double member access

### DIFF
--- a/src/rules/path-style.js
+++ b/src/rules/path-style.js
@@ -101,6 +101,9 @@ module.exports = {
         function convertToStringStyleWithVariables(node) {
             return `\`${node.elements
                 .map(el => {
+                    if (el.type === 'MemberExpression') {
+                        return `.\$\{${context.getSourceCode().getText(el)}\}`
+                    }
                     if (canBeDotNotation(el)) {
                         return `.${el.value}`
                     }

--- a/tests/lib/rules/path-style.js
+++ b/tests/lib/rules/path-style.js
@@ -75,5 +75,10 @@ ruleTester.run('path-style', rule, {
         errors: [{messageId: 'string', column: 18}],
         options: ['string'],
         output: "var t = _.get(x, 'a.b')"
+    }, {
+        code: 'var t = _.set(x, [b.a, b.c], a)',
+        errors: [{messageId: 'string', column: 18}],
+        options: ['string'],
+        output: 'var t = _.set(x, `${b.a}.${b.c}`, a)'
     }].map(withDefaultPragma)
 })


### PR DESCRIPTION
Fix for issue with nested member access and 'string' form.

Fixes #219 