### PR TITLE
Make Lodash a full dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
   "homepage": "https://github.com/wix/eslint-plugin-lodash",
   "bugs": "https://github.com/wix/eslint-plugin-lodash/issues",
   "peerDependencies": {
-    "eslint": ">=2",
-    "lodash": ">=4"
+    "eslint": ">=2"
   },
   "devDependencies": {
     "auto-changelog": "^2.0.0",
@@ -52,5 +51,7 @@
     "lodash"
   ],
   "license": "MIT",
-  "dependencies": {}
+  "dependencies": {
+    "lodash": ">=4"
+  }
 }


### PR DESCRIPTION
With Lodash declared as a peer dependency, it's impossible to use this plugin in projects that still use an older version of Lodash.  `npm` and `yarn` will complain about the peer version mismatch but will still use the hoisted lodash module rather than pulling in an up-to-date one for `eslint-plugin-lodash`.  Making this into a normal dependency should fix this, and is more accurate anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wix/eslint-plugin-lodash/255)
<!-- Reviewable:end -->
